### PR TITLE
Fix PathCache for webpack 2

### DIFF
--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -127,7 +127,10 @@ function resolvers(options, webpackResolver) {
         // index files like stylus but it uses all of webpack's configuration,
         // by default for example the module could be web_modules.
         .catch(function() { return whenWebpackResolver(context, path); })
-        .catch(function() { return null; });
+        .catch(function() { return null; })
+        .then(function(result) {
+          return Array.isArray(result) && result[1] && result[1].path || result
+        });
     }
   ];
 }


### PR DESCRIPTION
Modify PathCache's use of the webpack resolver to extract the path when used with webpack 2 and fall back to using the result as the path when the resolver returns a string.